### PR TITLE
[ELY-1713] Restore Javadoc Generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <version.org.wildfly.common>1.5.0.Alpha4</version.org.wildfly.common>
         <version.commons-io.commons-io>2.6</version.commons-io.commons-io>
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
+        <version.javax.annotation>1.2</version.javax.annotation>
 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
@@ -239,46 +240,137 @@
                         <notimestamp>true</notimestamp>
                         <doclint>none</doclint>
                         <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
+                        <additionalDependencies>
+                            <dependency>
+                                <groupId>javax.annotation</groupId>
+                                <artifactId>javax.annotation-api</artifactId>
+                                <version>${version.javax.annotation}</version>
+                            </dependency>
+                        </additionalDependencies>
+                        <sourcepath>
+                            ${project.basedir}/wildfly-elytron-asn1/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-audit/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth-server/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth-server-deprecated/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth-server-http/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth-server-sasl/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-auth-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-base/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-client/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-credential/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-credential-source-deprecated/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-credential-store/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-digest/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-basic/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-bearer/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-cert/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-deprecated/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-digest/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-form/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-spnego/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-sso/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-http-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-jacc/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-jacpi/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-json-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-mechanism/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-mechanism-digest/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-mechanism-oauth2/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-mechanism-scram/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-permission/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-realm/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-realm-jdbc/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-realm-ldap/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-realm-token/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-anonymous/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-auth-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-deprecated/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-digest/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-entity/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-external/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-gs2/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-gssapi/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-localuser/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-oauth2/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-otp/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-plain/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-sasl-scram/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-security-manager/src/main/java9/;
+                            ${project.basedir}/wildfly-elytron-security-manager/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-security-manager-action/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-ssl/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-tests/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-tests-common/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500-cert/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500-cert-acme/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500-cert-util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500-deprecated/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-x500-principal/src/main/java/;
+                        </sourcepath>
                         <sourceFileExcludes>
                             <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
                         </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
                     </configuration>
                     <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
+                        <execution><!-- mvn javadoc:aggregate@api-javadoc -->
+                            <id>api-javadoc</id>
+                            <goals>
+                                <goal>aggregate</goal>
+                            </goals>
+                            <configuration>
+                                <destDir>api-javadoc</destDir>
+                                <sourceFileIncludes>
+                                    <include>org/wildfly/security/*.java</include>
+                                    <include>org/wildfly/security/asn1/*.java</include>
+                                    <include>org/wildfly/security/auth/*.java</include>
+                                    <include>org/wildfly/security/auth/callback/*.java</include>
+                                    <include>org/wildfly/security/auth/client/*.java</include>
+                                    <include>org/wildfly/security/auth/jaspi/*.java</include>
+                                    <include>org/wildfly/security/auth/permission/*.java</include>
+                                    <include>org/wildfly/security/auth/principal/*.java</include>
+                                    <include>org/wildfly/security/auth/server/*.java</include>
+                                    <include>org/wildfly/security/auth/server/http/*.java</include>
+                                    <include>org/wildfly/security/auth/server/sasl/*.java</include>
+                                    <include>org/wildfly/security/auth/server/event/*.java</include>
+                                    <include>org/wildfly/security/auth/util/*.java</include>
+                                    <include>org/wildfly/security/authz/*.java</include>
+                                    <include>org/wildfly/security/credential/*.java</include>
+                                    <include>org/wildfly/security/credential/source/*.java</include>
+                                    <include>org/wildfly/security/credential/store/*.java</include>
+                                    <include>org/wildfly/security/evidence/*.java</include>
+                                    <include>org/wildfly/security/http/*.java</include>
+                                    <include>org/wildfly/security/key/*.java</include>
+                                    <include>org/wildfly/security/manager/*.java</include>
+                                    <include>org/wildfly/security/manager/_private/*.java</include>
+                                    <include>org/wildfly/security/manager/action/*.java</include>
+                                    <include>org/wildfly/security/mechanism/*.java</include>
+                                    <include>org/wildfly/security/mechanism/gssapi/*.java</include>
+                                    <include>org/wildfly/security/mechanism/_private/*.java</include>
+                                    <include>org/wildfly/security/password/*.java</include>
+                                    <include>org/wildfly/security/password/interfaces/*.java</include>
+                                    <include>org/wildfly/security/password/spec/*.java</include>
+                                    <include>org/wildfly/security/permission/*.java</include>
+                                    <include>org/wildfly/security/sasl/util/*.java</include>
+                                    <include>org/wildfly/security/sasl/auth/util/*.java</include>
+                                    <include>org/wildfly/security/ssl/*.java</include>
+                                    <include>org/wildfly/security/ssl/_private/*.java</include>
+                                    <include>org/wildfly/security/ssl/*.java</include>
+                                    <include>org/wildfly/security/x500/*.java</include>
+                                    <include>org/wildfly/security/x500/cert/*.java</include>
+                                    <include>org/wildfly/security/x500/principal/*.java</include>
+                                </sourceFileIncludes>
+                            </configuration>
+                        </execution>
+                        <execution><!-- mvn javadoc:aggregate@full-javadoc -->
                             <id>full-javadoc</id>
+                            <goals>
+                                <goal>aggregate</goal>
+                            </goals>
                             <configuration>
                                 <destDir>full-javadoc</destDir>
                                 <show>private</show>

--- a/wildfly-elytron-tests/pom.xml
+++ b/wildfly-elytron-tests/pom.xml
@@ -255,64 +255,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/wildfly-elytron-titan/pom.xml
+++ b/wildfly-elytron-titan/pom.xml
@@ -216,64 +216,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -232,64 +232,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
All javadoc will be generated at one place to /wildfly-elytron/target/site/apidocs/full-javadoc/

Additional dependency for javadoc plugin is needed because of this: 
https://stackoverflow.com/a/28755606