### PR TITLE
[ELY-1738] Clean up the 'wildfly-elytron-http' module as it currently…

### DIFF
--- a/http/base/src/main/java/org/wildfly/security/http/ElytronMessages.java
+++ b/http/base/src/main/java/org/wildfly/security/http/ElytronMessages.java
@@ -16,13 +16,12 @@
  * limitations under the License.
  */
 
-package org.wildfly.security.http._private;
+package org.wildfly.security.http;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.wildfly.security.http.HttpAuthenticationException;
 
 /**
  * Log messages and exceptions for Elytron.
@@ -31,7 +30,7 @@ import org.wildfly.security.http.HttpAuthenticationException;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 @MessageLogger(projectCode = "ELY", length = 5)
-public interface ElytronMessages extends BasicLogger {
+interface ElytronMessages extends BasicLogger {
 
     ElytronMessages log = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security");
     ElytronMessages httpUserPass = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.password");

--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -23,7 +23,7 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
 import static org.wildfly.security.http.HttpConstants.OK;
 import static org.wildfly.security.http.HttpConstants.SECURITY_IDENTITY;
-import static org.wildfly.security.http._private.ElytronMessages.log;
+import static org.wildfly.security.http.ElytronMessages.log;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/http/base/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -17,7 +17,7 @@
  */
 package org.wildfly.security.http;
 
-import static org.wildfly.security.http._private.ElytronMessages.httpClientCert;
+import static org.wildfly.security.http.ElytronMessages.httpClientCert;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/http/base/src/main/java/org/wildfly/security/http/HttpScope.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpScope.java
@@ -17,7 +17,7 @@
  */
 package org.wildfly.security.http;
 
-import static org.wildfly.security.http._private.ElytronMessages.log;
+import static org.wildfly.security.http.ElytronMessages.log;
 
 import java.io.InputStream;
 import java.util.function.Consumer;

--- a/http/basic/pom.xml
+++ b/http/basic/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-mechanism</artifactId>
+            <artifactId>wildfly-elytron-mechanism-http</artifactId>
         </dependency>
 
         <dependency>

--- a/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
+++ b/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
@@ -44,7 +44,7 @@ import org.wildfly.security.auth.callback.AvailableRealmsCallback;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
-import org.wildfly.security.http.impl.UsernamePasswordAuthenticationMechanism;
+import org.wildfly.security.mechanism.http.UsernamePasswordAuthenticationMechanism;
 
 /**
  * Implementation of the HTTP BASIC authentication mechanism

--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -51,7 +51,7 @@ import org.wildfly.security.http.HttpServerMechanismsResponder;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.http.Scope;
-import org.wildfly.security.http.impl.UsernamePasswordAuthenticationMechanism;
+import org.wildfly.security.mechanism.http.UsernamePasswordAuthenticationMechanism;
 
 /**
  * A generic FORM authentication mechanism which is usable in a number of different scenarios.

--- a/mechanism/http/pom.xml
+++ b/mechanism/http/pom.xml
@@ -30,40 +30,43 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>wildfly-elytron-http-form</artifactId>
+    <artifactId>wildfly-elytron-mechanism-http</artifactId>
 
-    <name>WildFly Elytron - HTTP Basic</name>
-    <description>WildFly Security HTTP Basic Mechanism Implementation</description>
+    <name>WildFly Elytron - Mechanism Http</name>
+    <description>WildFly Security Mechanism Http</description>
 
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>    
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-mechanism-http</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-mechanism</artifactId>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <!-- scope is compile ELY-1153 -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.kohsuke.metainf-services</groupId>
-            <artifactId>metainf-services</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.wildfly.common</groupId>
-            <artifactId>wildfly-common</artifactId>
-        </dependency>
     </dependencies>
 
 </project>
+

--- a/mechanism/http/src/main/java/org/wildfly/security/mechanism/http/ElytronMessages.java
+++ b/mechanism/http/src/main/java/org/wildfly/security/mechanism/http/ElytronMessages.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.mechanism.http;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Log messages and exceptions for Elytron.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@MessageLogger(projectCode = "ELY", length = 5)
+interface ElytronMessages extends BasicLogger {
+
+    ElytronMessages httpUserPass = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.password");
+}

--- a/mechanism/http/src/main/java/org/wildfly/security/mechanism/http/UsernamePasswordAuthenticationMechanism.java
+++ b/mechanism/http/src/main/java/org/wildfly/security/mechanism/http/UsernamePasswordAuthenticationMechanism.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.security.http.impl;
+package org.wildfly.security.mechanism.http;
 
 import java.io.IOException;
 
@@ -36,7 +36,7 @@ import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.password.interfaces.ClearPassword;
 
-import static org.wildfly.security.http._private.ElytronMessages.httpUserPass;
+import static org.wildfly.security.mechanism.http.ElytronMessages.httpUserPass;
 
 /**
  * A base class for HTTP mechanisms that operate on validation of plain text usernames and passwords.

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,12 @@
 
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-mechanism-http</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-mechanism-digest</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1250,6 +1256,7 @@
         <module>mechanism/base</module>
         <module>mechanism/digest</module>
         <module>mechanism/gssapi</module>
+        <module>mechanism/http</module>
         <module>mechanism/oauth2</module>
         <module>mechanism/scram</module>
         <module>permission</module>


### PR DESCRIPTION
… contains both public and private API

There were 2 private packages, both with 1 class: org.wildfly.security.http._private.ElytronMessages.java and org.wildfly.security.http.implUsernamePasswordAuthenticationMechanism.java.

I left the first one where it is, because only this module uses it.

I added new module wildfly-elytron-mechanism-http and put UsernamePasswordAuthenticationMechanism.java there (was also thinking of putting it to wildfly-elytron-mechanism module, but decided this way). Because the class uses ElytronMessages.httpUserPass, I added _private.ElytronMessages.java to this module. 


